### PR TITLE
campaign able to be sent only for pastoral-anouncements

### DIFF
--- a/src/app/api/pages/[id]/send-newsletter/route.tsx
+++ b/src/app/api/pages/[id]/send-newsletter/route.tsx
@@ -197,13 +197,13 @@ export async function POST(
     }
 
     const campaignResponse = await createCampaign(page as Page);
-    // const sendResponse = await sendCampaign(campaignResponse.data.id);
+    const sendResponse = process.env.NODE_ENV === 'production' ? await sendCampaign(campaignResponse.data.id) : null;
     await assignCampaign(id, campaignResponse.data.id);
 
     return NextResponse.json({
       message: "Newsletter created and sent successfully",
       campaignId: campaignResponse.id,
-      // sendStatus: sendResponse
+      sendStatus: sendResponse
     });
   } catch (error) {
     console.error("Error in newsletter process:", error);

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -106,6 +106,7 @@ export const Pages: CollectionConfig = {
       type: 'ui',
       admin: {
         position: 'sidebar',
+        condition: (_, siblingData) => siblingData.type === 'pastoral-announcements',
         components: {
           Field: {
             path: '@/_components/admin/SendNewsletterButton/index.tsx#SendNewsletterButton'


### PR DESCRIPTION
Re-enable sending campaigns, only for `PRODUCTION`